### PR TITLE
Add rating delta with date filter

### DIFF
--- a/app/OfficialRatings/Http/Controllers/OfficialRatingsController.php
+++ b/app/OfficialRatings/Http/Controllers/OfficialRatingsController.php
@@ -6,6 +6,7 @@ use App\OfficialRatings\Http\Resources\OfficialRatingPlayerResource;
 use App\OfficialRatings\Http\Resources\OfficialRatingResource;
 use App\OfficialRatings\Models\OfficialRating;
 use App\OfficialRatings\Services\OfficialRatingService;
+use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -95,5 +96,31 @@ readonly class OfficialRatingsController
         $ratings = $this->officialRatingService->getActiveRatings();
 
         return OfficialRatingResource::collection($ratings);
+    }
+
+    /**
+     * Get rating delta for current user since date
+     */
+    public function playerDelta(OfficialRating $officialRating, Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'date' => 'required|date',
+        ]);
+
+        $user = $request->user();
+
+        $delta = $this->officialRatingService->getPlayerDeltaSinceDate(
+            $officialRating,
+            $user->id,
+            Carbon::parse($validated['date']),
+        );
+
+        if (!$delta) {
+            return response()->json([
+                'message' => 'Player not found in this rating',
+            ], 404);
+        }
+
+        return response()->json($delta);
     }
 }

--- a/app/OfficialRatings/Routes/api.php
+++ b/app/OfficialRatings/Routes/api.php
@@ -18,6 +18,9 @@ Route::group(['prefix' => 'official-ratings'], static function () {
         [OfficialRatingsController::class, 'topPlayers'])->name('official-ratings.top-players');
     Route::get('/{officialRating}/players/{userId}',
         [OfficialRatingsController::class, 'playerRating'])->name('official-ratings.player-rating');
+
+    Route::middleware('auth:sanctum')->get('/{officialRating}/player-delta',
+        [OfficialRatingsController::class, 'playerDelta'])->name('official-ratings.player-delta');
 });
 // Admin official ratings routes
 Route::middleware(['auth:sanctum', AdminMiddleware::class])

--- a/resources/js/types/api.ts
+++ b/resources/js/types/api.ts
@@ -338,6 +338,15 @@ export interface OfficialRatingTournament {
     is_counting: boolean;
 }
 
+export interface RatingDelta {
+    current_position: number;
+    position_before: number;
+    position_delta: number;
+    current_points: number;
+    points_before: number;
+    points_delta: number;
+}
+
 export interface CreateOfficialRatingPayload {
     name: string;
     description: string | number;


### PR DESCRIPTION
## Summary
- allow logged users to request rating delta
- expose API endpoint to fetch player's delta since a chosen date
- compute delta in service
- display delta selector on rating show page
- extend API types

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68406027a96c832e902ac5394162ef1a