### PR TITLE
Add locale support in common UI components

### DIFF
--- a/resources/js/Components/ui/Modal.vue
+++ b/resources/js/Components/ui/Modal.vue
@@ -2,6 +2,7 @@
 import {computed, onMounted, onUnmounted, watch} from 'vue';
 import {XIcon} from 'lucide-vue-next';
 import {Button} from '@/Components/ui';
+import {useLocale} from '@/composables/useLocale';
 
 interface Props {
     show: boolean;
@@ -17,6 +18,8 @@ const props = withDefaults(defineProps<Props>(), {
     closeable: true,
     modalWrapperClass: 'bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full sm:mx-auto'
 });
+
+const { t } = useLocale();
 
 const emit = defineEmits(['close']);
 
@@ -105,7 +108,7 @@ const maxWidthClass = computed(() => {
                                     size="icon" variant="ghost"
                                     @click="closeModal">
                                 <XIcon class="h-5 w-5"/>
-                                <span class="sr-only">Close modal</span>
+                                <span class="sr-only">{{ t('Close modal') }}</span>
                             </Button>
                         </div>
 

--- a/resources/js/Components/ui/Toast.vue
+++ b/resources/js/Components/ui/Toast.vue
@@ -78,7 +78,7 @@
                                 class="bg-white rounded-md inline-flex text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                                 @click="hide"
                             >
-                                <span class="sr-only">Close</span>
+                                <span class="sr-only">{{ t('Close') }}</span>
                                 <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
                                     <path
                                         clip-rule="evenodd"
@@ -97,6 +97,7 @@
 
 <script lang="ts" setup>
 import {ref, watch, onMounted} from 'vue';
+import {useLocale} from '@/composables/useLocale';
 
 interface Props {
     show: boolean;
@@ -110,6 +111,8 @@ const props = withDefaults(defineProps<Props>(), {
     type: 'info',
     duration: 5000
 });
+
+const { t } = useLocale();
 
 const emit = defineEmits<{
     hide: [];

--- a/resources/lang/uk/translate.php
+++ b/resources/lang/uk/translate.php
@@ -308,6 +308,7 @@ return [
     'Score' => 'Рахунок',
     'Your opponent submitted a different result. If you submit this, their result will be discarded.' => 'Суперник подав інший результат. Якщо ви надішлете свій, його результат буде скасовано.',
     'Close' => 'Закрити',
+    'Close modal' => 'Закрити вікно',
     'Submit Result' => 'Надіслати результат',
     'Current Turn' => 'Поточний хід',
     'End Turn' => 'Завершити хід',


### PR DESCRIPTION
## Summary
- localize text in Modal and Toast components
- include new `Close modal` string in Ukrainian translations

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841d0a1a5e8832e8b6d3c946daa61a3