### PR TITLE
Add translations for admin pages

### DIFF
--- a/resources/js/pages/Admin/ConfirmedPlayers.vue
+++ b/resources/js/pages/Admin/ConfirmedPlayers.vue
@@ -33,7 +33,7 @@ const fetchLeague = async () => {
         const apiError = error as ApiError;
         message.value = {
             type: 'error',
-            text: apiError.message || 'Не вдалося завантажити лігу',
+            text: apiError.message || t('Failed to load league'),
         };
     }
 };
@@ -47,7 +47,7 @@ const fetchConfirmedPlayers = async () => {
         const apiError = error as ApiError;
         message.value = {
             type: 'error',
-            text: apiError.message || 'Не вдалося завантажити підтверджених гравців',
+            text: apiError.message || t('Failed to load confirmed players'),
         };
     } finally {
         isLoading.value = false;
@@ -56,7 +56,8 @@ const fetchConfirmedPlayers = async () => {
 
 // Deactivate individual player
 const deactivatePlayer = async (ratingId: number) => {
-    if (!confirm(t('Ви впевнені, що хочете деактивувати цього гравця? Він більше не зможе брати участь у цій лізі.'))) {
+    if (!confirm(t('Are you sure you want to deactivate this player? They will no longer be able to participate in this league.')))
+    {
         return;
     }
 
@@ -67,7 +68,7 @@ const deactivatePlayer = async (ratingId: number) => {
         });
         message.value = {
             type: 'success',
-            text: t('Гравця успішно деактивовано'),
+            text: t('Player deactivated successfully'),
         };
         // Refresh the list
         await fetchConfirmedPlayers();
@@ -75,7 +76,7 @@ const deactivatePlayer = async (ratingId: number) => {
         const apiError = error as ApiError;
         message.value = {
             type: 'error',
-            text: apiError.message || t('Не вдалося деактивувати гравця'),
+            text: apiError.message || t('Failed to deactivate player'),
         };
     } finally {
         isProcessing.value = false;
@@ -87,14 +88,14 @@ const bulkDeactivatePlayers = async () => {
     if (selectedPlayers.value.length === 0) {
         message.value = {
             type: 'error',
-            text: t('Будь ласка, виберіть хоча б одного гравця для деактивації'),
+            text: t('Please select at least one player to deactivate'),
         };
         return;
     }
 
     if (
         !confirm(
-            t('Ви впевнені, що хочете деактивувати :count гравців? Вони більше не зможуть брати участь у цій лізі.', {count: selectedPlayers.value.length}),
+            t('Are you sure you want to deactivate :count players? They will no longer be able to participate in this league.', {count: selectedPlayers.value.length}),
         )
     ) {
         return;
@@ -110,7 +111,7 @@ const bulkDeactivatePlayers = async () => {
         });
         message.value = {
             type: 'success',
-            text: t(':count гравців успішно деактивовано', {count: selectedPlayers.value.length}),
+            text: t(':count players deactivated successfully', {count: selectedPlayers.value.length}),
         };
         selectedPlayers.value = [];
         // Refresh the list
@@ -119,7 +120,7 @@ const bulkDeactivatePlayers = async () => {
         const apiError = error as ApiError;
         message.value = {
             type: 'error',
-            text: apiError.message || t('Не вдалося деактивувати гравців'),
+            text: apiError.message || t('Failed to deactivate players'),
         };
     } finally {
         isProcessing.value = false;
@@ -148,7 +149,7 @@ onMounted(async () => {
 </script>
 
 <template>
-    <Head :title="league ? t('Управління гравцями - :league', {league: league.name}) : t('Управління гравцями')"/>
+    <Head :title="league ? t('Manage Players - :league', {league: league.name}) : t('Manage Players')"/>
 
     <div class="py-12">
         <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
@@ -157,17 +158,17 @@ onMounted(async () => {
                 <Link :href="`/leagues/${leagueId}`">
                     <Button variant="outline">
                         <ArrowLeftIcon class="mr-2 h-4 w-4"/>
-                        {{ t('Назад до ліги') }}
+                        {{ t('Back to League') }}
                     </Button>
                 </Link>
 
                 <h1 class="text-2xl font-semibold">
-                    {{ league ? t('Управління гравцями - :league', {league: league.name}) : t('Управління гравцями') }}
+                    {{ league ? t('Manage Players - :league', {league: league.name}) : t('Manage Players') }}
                 </h1>
 
                 <div class="flex space-x-2">
                     <Link :href="`/admin/leagues/${leagueId}/pending-players`">
-                        <Button variant="outline"> {{ t('Непідтверджені гравці') }}</Button>
+                        <Button variant="outline"> {{ t('Pending Players') }}</Button>
                     </Link>
                 </div>
             </div>
@@ -182,8 +183,8 @@ onMounted(async () => {
 
             <Card>
                 <CardHeader>
-                    <CardTitle>{{ t('Підтверджені гравці') }}</CardTitle>
-                    <CardDescription> {{ t('Керуйте гравцями, які наразі активні в лізі') }}</CardDescription>
+                    <CardTitle>{{ t('Confirmed Players') }}</CardTitle>
+                    <CardDescription> {{ t('Manage players who are currently active in the league') }}</CardDescription>
                 </CardHeader>
                 <CardContent>
                     <!-- Loading state -->
@@ -194,7 +195,7 @@ onMounted(async () => {
                     <!-- Empty state -->
                     <div v-else-if="confirmedPlayers.length === 0"
                          class="py-8 text-center text-gray-500 dark:text-gray-400">
-                        {{ t('У цій лізі немає підтверджених гравців') }}
+                        {{ t('No confirmed players in this league') }}
                     </div>
 
                     <!-- Players list -->
@@ -209,14 +210,14 @@ onMounted(async () => {
                                     type="checkbox"
                                     @change="(e) => toggleSelectAll(e.target.checked)"
                                 />
-                                <label class="text-sm font-medium" for="select-all">{{ t('Вибрати всіх') }}</label>
+                                <label class="text-sm font-medium" for="select-all">{{ t('Select All') }}</label>
                             </div>
 
                             <Button :disabled="selectedPlayers.length === 0 || isProcessing" variant="destructive"
                                     @click="bulkDeactivatePlayers">
                                 <Spinner v-if="isProcessing" class="mr-2 h-4 w-4"/>
                                 <UserMinusIcon v-else class="mr-2 h-4 w-4"/>
-                                {{ t('Деактивувати вибраних') }} ({{ selectedPlayers.length }})
+                                {{ t('Deactivate Selected') }} ({{ selectedPlayers.length }})
                             </Button>
                         </div>
 
@@ -225,11 +226,11 @@ onMounted(async () => {
                                 <thead class="bg-gray-50 text-xs uppercase dark:bg-gray-800">
                                 <tr>
                                     <th class="px-4 py-3">&nbsp;</th>
-                                    <th class="px-4 py-3">{{ t('Позиція') }}</th>
-                                    <th class="px-4 py-3">{{ t("Ім'я") }}</th>
-                                    <th class="px-4 py-3">{{ t('Рейтинг') }}</th>
-                                    <th class="px-4 py-3">{{ t('Статистика (В/П)') }}</th>
-                                    <th class="px-4 py-3 text-right">{{ t('Дії') }}</th>
+                                    <th class="px-4 py-3">{{ t('Position') }}</th>
+                                    <th class="px-4 py-3">{{ t('Name') }}</th>
+                                    <th class="px-4 py-3">{{ t('Rating') }}</th>
+                                    <th class="px-4 py-3">{{ t('Stats (W/L)') }}</th>
+                                    <th class="px-4 py-3 text-right">{{ t('Actions') }}</th>
                                 </tr>
                                 </thead>
                                 <tbody>
@@ -258,7 +259,7 @@ onMounted(async () => {
                                         <Button :disabled="isProcessing" size="sm" variant="destructive"
                                                 @click="deactivatePlayer(player.id)">
                                             <UserMinusIcon class="mr-1 h-4 w-4"/>
-                                            {{ t('Деактивувати') }}
+                                            {{ t('Deactivate') }}
                                         </Button>
                                     </td>
                                 </tr>

--- a/resources/js/pages/Admin/Tournaments/Create.vue
+++ b/resources/js/pages/Admin/Tournaments/Create.vue
@@ -200,25 +200,25 @@ onMounted(() => {
                         <!-- Basic Information -->
                         <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
                             <div class="space-y-2">
-                                <Label for="name">Tournament Name *</Label>
+                                <Label for="name">{{ t('Tournament Name') }} *</Label>
                                 <Input
                                     id="name"
                                     v-model="form.name"
-                                    placeholder="Enter tournament name"
+                                      :placeholder="t('Enter tournament name')"
                                     required
                                 />
                             </div>
 
                             <div class="space-y-2">
-                                <Label for="game_id">Game *</Label>
+                                <Label for="game_id">{{ t('Game') }} *</Label>
                                 <Select v-model="form.game_id" required>
                                     <SelectTrigger>
-                                        <SelectValue placeholder="Select specific game"/>
+                                          <SelectValue :placeholder="t('Select specific game')"/>
                                     </SelectTrigger>
                                     <SelectContent>
-                                        <SelectItem v-if="isLoadingGames" :value="0">
-                                            Loading games...
-                                        </SelectItem>
+                                          <SelectItem v-if="isLoadingGames" :value="0">
+                                              {{ t('Loading games...') }}
+                                          </SelectItem>
                                         <SelectItem
                                             v-for="game in filteredGames"
                                             v-else
@@ -229,16 +229,16 @@ onMounted(() => {
                                         </SelectItem>
                                     </SelectContent>
                                 </Select>
-                                <p v-if="form.official_rating_id" class="text-sm text-gray-500 dark:text-gray-400">
-                                    Games filtered by selected rating type
-                                </p>
+                                  <p v-if="form.official_rating_id" class="text-sm text-gray-500 dark:text-gray-400">
+                                      {{ t('Games filtered by selected rating type') }}
+                                  </p>
                             </div>
                         </div>
 
                         <!-- Dates -->
                         <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
                             <div class="space-y-2">
-                                <Label for="start_date">Start Date *</Label>
+                                <Label for="start_date">{{ t('Start Date') }} *</Label>
                                 <Input
                                     id="start_date"
                                     v-model="form.start_date"
@@ -248,7 +248,7 @@ onMounted(() => {
                             </div>
 
                             <div class="space-y-2">
-                                <Label for="end_date">End Date *</Label>
+                                <Label for="end_date">{{ t('End Date') }} *</Label>
                                 <Input
                                     id="end_date"
                                     v-model="form.end_date"
@@ -260,22 +260,22 @@ onMounted(() => {
 
                         <!-- Official Rating Association -->
                         <div class="space-y-4">
-                            <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 flex items-center gap-2">
-                                <StarIcon class="h-5 w-5"/>
-                                Official Rating Association
-                            </h3>
+                              <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 flex items-center gap-2">
+                                  <StarIcon class="h-5 w-5"/>
+                                  {{ t('Official Rating Association') }}
+                              </h3>
 
                             <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
                                 <div class="space-y-2">
-                                    <Label for="official_rating_id">Official Rating</Label>
+                                      <Label for="official_rating_id">{{ t('Official Rating') }}</Label>
                                     <Select v-model="form.official_rating_id">
                                         <SelectTrigger>
-                                            <SelectValue placeholder="Select official rating (optional)"/>
+                                              <SelectValue :placeholder="t('Select official rating (optional)')"/>
                                         </SelectTrigger>
                                         <SelectContent>
-                                            <SelectItem v-if="isLoadingRatings" :value="0">
-                                                Loading ratings...
-                                            </SelectItem>
+                                              <SelectItem v-if="isLoadingRatings" :value="0">
+                                                  {{ t('Loading ratings...') }}
+                                              </SelectItem>
                                             <SelectItem
                                                 v-for="rating in filteredOfficialRatings"
                                                 v-else
@@ -286,13 +286,13 @@ onMounted(() => {
                                             </SelectItem>
                                         </SelectContent>
                                     </Select>
-                                    <p class="text-sm text-gray-500 dark:text-gray-400">
-                                        Associate this tournament with an official rating system
-                                    </p>
+                                      <p class="text-sm text-gray-500 dark:text-gray-400">
+                                          {{ t('Associate this tournament with an official rating system') }}
+                                      </p>
                                 </div>
 
                                 <div class="space-y-2">
-                                    <Label for="rating_coefficient">Rating Coefficient</Label>
+                                      <Label for="rating_coefficient">{{ t('Rating Coefficient') }}</Label>
                                     <Input
                                         id="rating_coefficient"
                                         v-model.number="form.rating_coefficient"
@@ -302,26 +302,26 @@ onMounted(() => {
                                         step="0.1"
                                         type="number"
                                     />
-                                    <p class="text-sm text-gray-500 dark:text-gray-400">
-                                        Multiplier for rating points (0.1 - 5.0)
-                                    </p>
+                                      <p class="text-sm text-gray-500 dark:text-gray-400">
+                                          {{ t('Multiplier for rating points (0.1 - 5.0)') }}
+                                      </p>
                                 </div>
                             </div>
                         </div>
 
                         <!-- Location -->
                         <div class="space-y-4">
-                            <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 flex items-center gap-2">
-                                <MapPinIcon class="h-5 w-5"/>
-                                Location
-                            </h3>
+                              <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 flex items-center gap-2">
+                                  <MapPinIcon class="h-5 w-5"/>
+                                  {{ t('Location') }}
+                              </h3>
 
                             <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
                                 <div class="space-y-2">
-                                    <Label for="city_id">City</Label>
+                                      <Label for="city_id">{{ t('City') }}</Label>
                                     <Select v-model="form.city_id">
                                         <SelectTrigger>
-                                            <SelectValue placeholder="Select city"/>
+                                              <SelectValue :placeholder="t('Select city')"/>
                                         </SelectTrigger>
                                         <SelectContent>
                                             <SelectItem
@@ -336,10 +336,10 @@ onMounted(() => {
                                 </div>
 
                                 <div class="space-y-2">
-                                    <Label for="club_id">Club</Label>
+                                      <Label for="club_id">{{ t('Club') }}</Label>
                                     <Select v-model="form.club_id" :disabled="!form.city_id">
                                         <SelectTrigger>
-                                            <SelectValue placeholder="Select club"/>
+                                              <SelectValue :placeholder="t('Select club')"/>
                                         </SelectTrigger>
                                         <SelectContent>
                                             <SelectItem
@@ -357,11 +357,11 @@ onMounted(() => {
 
                         <!-- Financial Information -->
                         <div class="space-y-4">
-                            <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">Financial Details</h3>
+                              <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ t('Financial Details') }}</h3>
 
                             <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
                                 <div class="space-y-2">
-                                    <Label for="entry_fee">Entry Fee (₴)</Label>
+                                      <Label for="entry_fee">{{ t('Entry Fee') }} (₴)</Label>
                                     <Input
                                         id="entry_fee"
                                         v-model.number="form.entry_fee"
@@ -372,7 +372,7 @@ onMounted(() => {
                                 </div>
 
                                 <div class="space-y-2">
-                                    <Label for="prize_pool">Prize Pool (₴)</Label>
+                                      <Label for="prize_pool">{{ t('Prize Pool') }} (₴)</Label>
                                     <Input
                                         id="prize_pool"
                                         v-model.number="form.prize_pool"
@@ -383,12 +383,12 @@ onMounted(() => {
                                 </div>
 
                                 <div class="space-y-2">
-                                    <Label for="max_participants">Max Participants</Label>
+                                      <Label for="max_participants">{{ t('Max Participants') }}</Label>
                                     <Input
                                         id="max_participants"
                                         v-model.number="form.max_participants"
                                         min="2"
-                                        placeholder="Unlimited"
+                                          :placeholder="t('Unlimited')"
                                         type="number"
                                     />
                                 </div>
@@ -397,44 +397,44 @@ onMounted(() => {
 
                         <!-- Additional Details -->
                         <div class="space-y-4">
-                            <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">Additional Information</h3>
+                              <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ t('Additional Information') }}</h3>
 
                             <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
                                 <div class="space-y-2">
-                                    <Label for="organizer">Organizer</Label>
+                                    <Label for="organizer">{{ t('Organizer') }}</Label>
                                     <Input
                                         id="organizer"
                                         v-model="form.organizer"
-                                        placeholder="Tournament organizer"
+                                        :placeholder="t('Tournament organizer')"
                                     />
                                 </div>
 
                                 <div class="space-y-2">
-                                    <Label for="format">Format</Label>
+                                    <Label for="format">{{ t('Format') }}</Label>
                                     <Input
                                         id="format"
                                         v-model="form.format"
-                                        placeholder="e.g., Single Elimination, Round Robin"
+                                        :placeholder="t('e.g., Single Elimination, Round Robin')"
                                     />
                                 </div>
                             </div>
 
                             <div class="space-y-2">
-                                <Label for="details">Description</Label>
+                                <Label for="details">{{ t('Description') }}</Label>
                                 <Textarea
                                     id="details"
                                     v-model="form.details"
-                                    placeholder="Tournament description and additional details"
+                                    :placeholder="t('Tournament description and additional details')"
                                     rows="3"
                                 />
                             </div>
 
                             <div class="space-y-2">
-                                <Label for="regulation">Regulation</Label>
+                                <Label for="regulation">{{ t('Regulation') }}</Label>
                                 <Textarea
                                     id="regulation"
                                     v-model="form.regulation"
-                                    placeholder="Tournament rules and regulations"
+                                    :placeholder="t('Tournament rules and regulations')"
                                     rows="4"
                                 />
                             </div>
@@ -443,14 +443,14 @@ onMounted(() => {
                         <!-- Form Actions -->
                         <div class="flex justify-end space-x-4 border-t pt-6">
                             <Button type="button" variant="outline" @click="handleCancel">
-                                Cancel
+                                {{ t('Cancel') }}
                             </Button>
                             <Button
                                 :disabled="!isFormValid || isSubmitting"
                                 type="submit"
                             >
                                 <Spinner v-if="isSubmitting" class="mr-2 h-4 w-4"/>
-                                {{ isSubmitting ? 'Creating...' : 'Create Tournament' }}
+                                {{ isSubmitting ? t('Creating...') : t('Create Tournament') }}
                             </Button>
                         </div>
                     </form>
@@ -460,7 +460,7 @@ onMounted(() => {
             <!-- Error Display -->
             <div v-if="createApi.error.value"
                  class="mt-4 rounded bg-red-100 p-4 text-red-600 dark:bg-red-900/30 dark:text-red-400">
-                Error creating tournament: {{ createApi.error.value.message }}
+                {{ t('Error creating tournament') }}: {{ createApi.error.value.message }}
             </div>
         </div>
     </div>

--- a/resources/lang/uk/translate.php
+++ b/resources/lang/uk/translate.php
@@ -719,4 +719,54 @@ return [
     'Loading applications...'                                                                                                => 'Завантаження заявок...',
     'No Applications Yet'                                                                                                    => 'Заявок поки що немає',
     'No one has applied to this tournament yet.'                                                                             => 'Ще ніхто не подав заявку на цей турнір.',
+    'Tournament Name'
+                                             => 'Назва турніру',
+    'Enter tournament name'
+                                             => 'Введіть назву турніру',
+    'Select specific game'
+                                             => 'Оберіть конкретну гру',
+    'Loading games...'
+                                             => 'Завантаження ігор...',
+    'Games filtered by selected rating type'
+                                             => 'Ігри відфільтровані за обраним типом рейтингу',
+    'Official Rating Association'
+                                             => 'Прив\'язка до офіційного рейтингу',
+    'Official Rating'
+                                             => 'Офіційний рейтинг',
+    'Select official rating (optional)'
+                                             => 'Оберіть офіційний рейтинг (необов\'язково)',
+    'Loading ratings...'
+                                             => 'Завантаження рейтингів...',
+    'Associate this tournament with an official rating system'
+                                             => 'Пов\'яжіть цей турнір з офіційною рейтинговою системою',
+    'Rating Coefficient'
+                                             => 'Коефіцієнт рейтингу',
+    'Multiplier for rating points (0.1 - 5.0)'
+                                             => 'Множник рейтингових очок (0.1 - 5.0)',
+    'Location'
+                                             => 'Місце проведення',
+    'City'
+                                             => 'Місто',
+    'Select city'
+                                             => 'Оберіть місто',
+    'Club'
+                                             => 'Клуб',
+    'Select club'
+                                             => 'Оберіть клуб',
+    'Financial Details'
+                                             => 'Фінансова інформація',
+    'Additional Information'
+                                             => 'Додаткова інформація',
+    'Tournament organizer'
+                                             => 'Організатор турніру',
+    'e.g., Single Elimination, Round Robin'
+                                             => 'напр., Олімпійська система, Круговий турнір',
+    'Tournament description and additional details'
+                                             => 'Опис турніру та додаткова інформація',
+    'Tournament rules and regulations'
+                                             => 'Правила та регламент турніру',
+    'Error creating tournament'
+                                             => 'Помилка створення турніру',
+    'Creating...'
+                                             => 'Створення...',
 ];


### PR DESCRIPTION
## Summary
- localized admin player management page
- added translations to tournament creation form
- expanded Ukrainian translation dictionary for tournament creation strings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842f3c48084832e998041b5569d4651