### PR TITLE
Fix action column visibility

### DIFF
--- a/resources/js/pages/Leagues/Index.vue
+++ b/resources/js/pages/Leagues/Index.vue
@@ -185,7 +185,9 @@ onMounted(() => {
                                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
                                     {{ t('Start Date') }}
                                 </th>
-                                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                <th
+                                    class="sticky right-0 z-10 px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-50 dark:bg-gray-800"
+                                >
                                     {{ t('Actions') }}
                                 </th>
                             </tr>
@@ -263,7 +265,7 @@ onMounted(() => {
                                 </td>
 
                                 <!-- Actions -->
-                                <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                <td class="sticky right-0 z-10 px-6 py-4 whitespace-nowrap text-right text-sm font-medium bg-white dark:bg-gray-900">
                                     <div class="flex justify-end space-x-2">
                                         <!-- Everyone can view -->
                                         <Link

--- a/resources/js/pages/Leagues/MultiplayerGames/Index.vue
+++ b/resources/js/pages/Leagues/MultiplayerGames/Index.vue
@@ -275,7 +275,9 @@ onMounted(() => {
                                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
                                     {{ t('Registration') }}
                                 </th>
-                                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                <th
+                                    class="sticky right-0 z-10 px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-50 dark:bg-gray-800"
+                                >
                                     {{ t('Actions') }}
                                 </th>
                             </tr>
@@ -360,7 +362,7 @@ onMounted(() => {
                                 </td>
 
                                 <!-- Actions -->
-                                <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                <td class="sticky right-0 z-10 px-6 py-4 whitespace-nowrap text-right text-sm font-medium bg-white dark:bg-gray-900">
                                     <div class="flex justify-end space-x-2">
                                         <!-- Everyone can view -->
                                         <Link :href="`/leagues/${leagueId}/multiplayer-games/${game.id}`">

--- a/resources/js/pages/OfficialRatings/Index.vue
+++ b/resources/js/pages/OfficialRatings/Index.vue
@@ -139,7 +139,9 @@ onMounted(() => {
                                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
                                     {{ t('Tournaments') }}
                                 </th>
-                                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                <th
+                                    class="sticky right-0 z-10 px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-50 dark:bg-gray-800"
+                                >
                                     {{ t('Actions') }}
                                 </th>
                             </tr>
@@ -211,7 +213,7 @@ onMounted(() => {
                                 </td>
 
                                 <!-- Actions -->
-                                <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                <td class="sticky right-0 z-10 px-6 py-4 whitespace-nowrap text-right text-sm font-medium bg-white dark:bg-gray-900">
                                     <div class="flex justify-end space-x-2">
                                         <!-- Everyone can view -->
                                         <Link :href="`/official-ratings/${rating.id}`">

--- a/resources/js/pages/Tournaments/Index.vue
+++ b/resources/js/pages/Tournaments/Index.vue
@@ -296,7 +296,9 @@ onMounted(() => {
                                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
                                     {{ t('Prize Pool') }}
                                 </th>
-                                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                <th
+                                    class="sticky right-0 z-10 px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-50 dark:bg-gray-800"
+                                >
                                     {{ t('Actions') }}
                                 </th>
                             </tr>
@@ -432,7 +434,7 @@ onMounted(() => {
                                 </td>
 
                                 <!-- Actions -->
-                                <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                <td class="sticky right-0 z-10 px-6 py-4 whitespace-nowrap text-right text-sm font-medium bg-white dark:bg-gray-900">
                                     <div class="flex justify-end space-x-2">
                                         <!-- Everyone can view -->
                                         <Link :href="`/tournaments/${tournament.id}`">


### PR DESCRIPTION
## Summary
- keep Actions column sticky on tables across index pages

## Testing
- `npm run lint` *(fails: cannot find eslint dependencies)*
- `npm run format:check` *(fails: cannot find prettier plugin)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432c9814a4832ebc4365776b6034a6