### PR TITLE
Add tournament structure management UI

### DIFF
--- a/resources/js/Components/Tournament/Bracket/BracketViewer.vue
+++ b/resources/js/Components/Tournament/Bracket/BracketViewer.vue
@@ -1,0 +1,44 @@
+<script lang="ts" setup>
+import {Card, CardContent, CardHeader, CardTitle} from '@/Components/ui';
+import type {TournamentBracket, TournamentMatch} from '@/types/tournament';
+
+const props = defineProps<{ brackets: TournamentBracket[] }>();
+
+const roundsForBracket = (bracket: TournamentBracket) => {
+    const map = new Map<number, TournamentMatch[]>();
+    bracket.matches?.forEach(m => {
+        if (!map.has(m.round_number)) map.set(m.round_number, []);
+        map.get(m.round_number)!.push(m);
+    });
+    return Array.from(map.entries()).sort((a,b) => a[0]-b[0]);
+};
+</script>
+
+<template>
+    <div class="space-y-6">
+        <Card v-for="bracket in props.brackets" :key="bracket.id">
+            <CardHeader>
+                <CardTitle>{{ bracket.bracket_type_display }}</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <div class="flex space-x-6 overflow-auto">
+                    <div
+                        v-for="([round, matches]) in roundsForBracket(bracket)"
+                        :key="round"
+                        class="space-y-4"
+                    >
+                        <div class="font-semibold text-center">{{ $t('Round') }} {{ round }}</div>
+                        <div
+                            v-for="match in matches"
+                            :key="match.id"
+                            class="w-48 rounded border p-2 text-sm"
+                        >
+                            <div>{{ match.participant_1_name || 'TBD' }} vs {{ match.participant_2_name || 'TBD' }}</div>
+                            <div class="text-xs text-gray-500">{{ match.status_display }}</div>
+                        </div>
+                    </div>
+                </div>
+            </CardContent>
+        </Card>
+    </div>
+</template>

--- a/resources/js/Components/Tournament/Group/GroupStandings.vue
+++ b/resources/js/Components/Tournament/Group/GroupStandings.vue
@@ -1,0 +1,39 @@
+<script lang="ts" setup>
+import {Card, CardContent, CardHeader, CardTitle} from '@/Components/ui';
+import type {TournamentGroup} from '@/types/tournament';
+
+const props = defineProps<{ groups: TournamentGroup[] }>();
+</script>
+
+<template>
+    <div class="space-y-6">
+        <Card v-for="group in props.groups" :key="group.id">
+            <CardHeader>
+                <CardTitle>{{ group.display_name || group.name }}</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <table v-if="group.standings" class="min-w-full text-sm">
+                    <thead>
+                    <tr class="border-b dark:border-gray-700 text-left">
+                        <th class="px-2 py-1">#</th>
+                        <th class="px-2 py-1">{{ $t('Player') }}</th>
+                        <th class="px-2 py-1 text-center">W</th>
+                        <th class="px-2 py-1 text-center">L</th>
+                        <th class="px-2 py-1 text-center">±</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr v-for="row in group.standings" :key="row.participant_id" class="border-b dark:border-gray-700">
+                        <td class="px-2 py-1">{{ row.position }}</td>
+                        <td class="px-2 py-1">{{ row.participant_name }}</td>
+                        <td class="px-2 py-1 text-center">{{ row.wins }}</td>
+                        <td class="px-2 py-1 text-center">{{ row.losses }}</td>
+                        <td class="px-2 py-1 text-center">{{ row.games_difference }}</td>
+                    </tr>
+                    </tbody>
+                </table>
+                <div v-else class="text-center text-gray-500 py-4">{{ $t('No standings yet') }}</div>
+            </CardContent>
+        </Card>
+    </div>
+</template>

--- a/resources/js/pages/Admin/Tournaments/Create.vue
+++ b/resources/js/pages/Admin/Tournaments/Create.vue
@@ -18,6 +18,7 @@ import {
 } from '@/Components/ui';
 import {useProfileApi} from '@/composables/useProfileApi';
 import {useTournaments} from '@/composables/useTournaments';
+import FormatSelector from '@/Components/Tournament/Structure/FormatSelector.vue';
 import AuthenticatedLayout from '@/layouts/AuthenticatedLayout.vue';
 import {apiClient} from '@/lib/apiClient';
 import {useLocale} from '@/composables/useLocale';
@@ -37,6 +38,15 @@ const {fetchCities, fetchClubs} = useProfileApi();
 const form = ref<CreateTournamentPayload & {
     official_rating_id?: number;
     rating_coefficient?: number;
+    tournament_format: string;
+    seeding_method: string;
+    number_of_groups?: number;
+    players_per_group?: number;
+    advance_per_group?: number;
+    best_of_rule?: string;
+    has_lower_bracket?: boolean;
+    is_team_tournament?: boolean;
+    team_size?: number;
 }>({
     name: '',
     regulation: '',
@@ -52,6 +62,15 @@ const form = ref<CreateTournamentPayload & {
     prize_distribution: [],
     organizer: '',
     format: '',
+    tournament_format: 'single_elimination',
+    seeding_method: 'manual',
+    number_of_groups: undefined,
+    players_per_group: undefined,
+    advance_per_group: undefined,
+    best_of_rule: 'best_of_3',
+    has_lower_bracket: false,
+    is_team_tournament: false,
+    team_size: 2,
     official_rating_id: undefined,
     rating_coefficient: 1.0,
 });
@@ -80,7 +99,9 @@ const isFormValid = computed(() => {
     return form.value.name.trim() !== '' &&
         form.value.game_id > 0 &&
         form.value.start_date !== '' &&
-        form.value.end_date !== '';
+        form.value.end_date !== '' &&
+        form.value.tournament_format !== '' &&
+        form.value.seeding_method !== '';
 });
 
 // Watch for official rating changes to filter games
@@ -308,6 +329,9 @@ onMounted(() => {
                                 </div>
                             </div>
                         </div>
+
+                        <!-- Tournament Format -->
+                        <FormatSelector v-model="form" />
 
                         <!-- Location -->
                         <div class="space-y-4">

--- a/resources/js/pages/Admin/Tournaments/Edit.vue
+++ b/resources/js/pages/Admin/Tournaments/Edit.vue
@@ -18,6 +18,7 @@ import {
 } from '@/Components/ui';
 import {useProfileApi} from '@/composables/useProfileApi';
 import {useTournaments} from '@/composables/useTournaments';
+import FormatSelector from '@/Components/Tournament/Structure/FormatSelector.vue';
 import AuthenticatedLayout from '@/layouts/AuthenticatedLayout.vue';
 import {apiClient} from '@/lib/apiClient';
 import type {City, Club, Game, OfficialRating, Tournament} from '@/types/api';
@@ -49,6 +50,15 @@ const form = ref({
     prize_pool: 0,
     organizer: '',
     format: '',
+    tournament_format: 'single_elimination',
+    seeding_method: 'manual',
+    number_of_groups: undefined as number | undefined,
+    players_per_group: undefined as number | undefined,
+    advance_per_group: undefined as number | undefined,
+    best_of_rule: 'best_of_3',
+    has_lower_bracket: false,
+    is_team_tournament: false,
+    team_size: 2,
     status: 'upcoming' as 'upcoming' | 'active' | 'completed' | 'cancelled',
     official_rating_id: undefined as number | undefined,
     rating_coefficient: 1.0,
@@ -81,7 +91,9 @@ const isFormValid = computed(() => {
     return form.value.name.trim() !== '' &&
         form.value.game_id > 0 &&
         form.value.start_date !== '' &&
-        form.value.end_date !== '';
+        form.value.end_date !== '' &&
+        form.value.tournament_format !== '' &&
+        form.value.seeding_method !== '';
 });
 
 const statusOptions = [
@@ -173,6 +185,15 @@ const loadTournament = async () => {
             prize_pool: tournament.value.prize_pool || 0,
             organizer: tournament.value.organizer || '',
             format: tournament.value.format || '',
+            tournament_format: tournament.value.tournament_format || 'single_elimination',
+            seeding_method: tournament.value.seeding_method || 'manual',
+            number_of_groups: tournament.value.number_of_groups || undefined,
+            players_per_group: tournament.value.players_per_group || undefined,
+            advance_per_group: tournament.value.advance_per_group || undefined,
+            best_of_rule: tournament.value.best_of_rule || 'best_of_3',
+            has_lower_bracket: tournament.value.has_lower_bracket || false,
+            is_team_tournament: tournament.value.is_team_tournament || false,
+            team_size: tournament.value.team_size || 2,
             status: tournament.value.status as any,
             official_rating_id: tournament.value.official_ratings?.[0]?.id,
             rating_coefficient: tournament.value.official_ratings?.[0]?.rating_coefficient || 1.0,
@@ -410,6 +431,9 @@ onMounted(async () => {
                                 </div>
                             </div>
                         </div>
+
+                        <!-- Tournament Format -->
+                        <FormatSelector v-model="form" />
 
                         <!-- Location -->
                         <div class="space-y-4">

--- a/resources/js/pages/Admin/Tournaments/Players.vue
+++ b/resources/js/pages/Admin/Tournaments/Players.vue
@@ -34,7 +34,8 @@ const {
     addPlayerToTournament,
     addNewPlayerToTournament,
     removePlayerFromTournament,
-    searchUsers
+    searchUsers,
+    updateTournamentPlayer
 } = useTournaments();
 
 // Data
@@ -155,6 +156,11 @@ const handleRemovePlayer = async (playerId: number) => {
     if (success) {
         await loadPlayers();
     }
+};
+
+const updateSeed = async (playerId: number, seed: number) => {
+    const api = updateTournamentPlayer(props.tournamentId, playerId);
+    await api.execute({seed});
 };
 
 const resetNewPlayerForm = () => {
@@ -294,6 +300,7 @@ onMounted(() => {
                             <thead>
                             <tr class="border-b dark:border-gray-700">
                                 <th class="px-4 py-3 text-left">{{ t('Position') }}</th>
+                                <th class="px-4 py-3 text-left">{{ t('Seed') }}</th>
                                 <th class="px-4 py-3 text-left">{{ t('Player') }}</th>
                                 <th class="px-4 py-3 text-center">{{ t('Status') }}</th>
                                 <th class="px-4 py-3 text-center">{{ t('Rating Points') }}</th>
@@ -313,6 +320,15 @@ onMounted(() => {
                                 <td class="px-4 py-3">
                                     <span v-if="player.position" class="font-bold">#{{ player.position }}</span>
                                     <span v-else class="text-gray-400">—</span>
+                                </td>
+                                <td class="px-4 py-3">
+                                    <input
+                                        v-model.number="player.seed"
+                                        class="w-16 rounded border-gray-300 text-center"
+                                        min="1"
+                                        type="number"
+                                        @change="updateSeed(player.id, player.seed)"
+                                    />
                                 </td>
                                 <td class="px-4 py-3">
                                     <div>

--- a/resources/js/pages/Admin/Tournaments/Structure/Schedule.vue
+++ b/resources/js/pages/Admin/Tournaments/Structure/Schedule.vue
@@ -36,7 +36,6 @@ const {fetchTournament} = useTournaments();
 const {fetchClubs} = useProfileApi();
 const {
     fetchMatches,
-    updateMatch,
     enterMatchResult,
     startMatch,
     cancelMatch,


### PR DESCRIPTION
## Summary
- integrate FormatSelector into tournament create and edit pages
- allow editing player seeds in player manager
- implement group standings and bracket viewer components
- show groups, brackets and schedule on tournament page
- lint fixes

## Testing
- `npm run lint`
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684847010dec832ea8906a264955ad0e